### PR TITLE
bugfix: allow client to run in strict mode

### DIFF
--- a/client-library.js
+++ b/client-library.js
@@ -667,12 +667,12 @@
 
         // We'll define functions for all HTML tags...
         var function_for_tag = (tag) =>
-            (...arguments) => {
+            (...args) => {
                 var children = []
                 var attrs = {style: {}}
                 
-                for (var i=0; i<arguments.length; i++) {
-                    var arg = arguments[i]
+                for (var i=0; i<args.length; i++) {
+                    var arg = args[i]
 
                     if (arg === undefined)
                         continue

--- a/statebus.js
+++ b/statebus.js
@@ -2,7 +2,7 @@
 (function(name, definition) {
     if (typeof module != 'undefined') module.exports = definition()
     else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
-    else this[name] = definition()
+    else if(this) this[name] = definition()
 }('statebus', function() {statelog_indent = 0; var busses = {}, bus_count = 0, executing_funk, global_funk, funks = {}, clean_timer, symbols, nodejs = typeof window === 'undefined'; function make_bus (options) {
 
 


### PR DESCRIPTION
tested locally, this allows for the script to be included as esm with the least amount of friction:

```
import "http://localhost:8042/statebus.js"
import "http://localhost:8042/client-library.js"
import "http://unpkg.com/braidify/braidify-client.js"
```