### PR TITLE
bugfix: allow client to run in strict mode

### DIFF
--- a/client-library.js
+++ b/client-library.js
@@ -457,7 +457,7 @@
     // *****************
     // Re-rendering react components
     var re_render_scheduled = false
-    re_rendering = false
+    var re_rendering = false
     function schedule_re_render() {
         if (!re_render_scheduled) {
             requestAnimationFrame(function () {
@@ -617,7 +617,8 @@
                     if (this.state.value) new_props.value = this.state.value
                     new_props.onChange = this.onChange
                     return element(new_props)
-                }
+              
+              }
             }))
         }
 
@@ -667,12 +668,12 @@
 
         // We'll define functions for all HTML tags...
         var function_for_tag = (tag) =>
-            (...arguments) => {
+            (...args) => {
                 var children = []
                 var attrs = {style: {}}
                 
-                for (var i=0; i<arguments.length; i++) {
-                    var arg = arguments[i]
+                for (var i=0; i<args.length; i++) {
+                    var arg = args[i]
 
                     if (arg === undefined)
                         continue

--- a/statebus.js
+++ b/statebus.js
@@ -2,8 +2,10 @@
 (function(name, definition) {
     if (typeof module != 'undefined') module.exports = definition()
     else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
-    else this[name] = definition()
-}('statebus', function() {statelog_indent = 0; var busses = {}, bus_count = 0, executing_funk, global_funk, funks = {}, clean_timer, symbols, nodejs = typeof window === 'undefined'; function make_bus (options) {
+    else if(this) this[name] = definition()
+    else if(window) window[name] = definition()
+
+}('statebus', function() {var statelog_indent = 0; var busses = {}, bus_count = 0, executing_funk, global_funk, funks = {}, clean_timer, symbols, nodejs = typeof window === 'undefined'; function make_bus (options) {
 
 
     // ****************
@@ -731,6 +733,7 @@
             }
         }
 
+        let handler
         // Now iterate through prefixes
         for (var i=0; i < wildcard_handlers.length; i++) {
             handler = wildcard_handlers[i]


### PR DESCRIPTION
tested locally, this allows for the scripts to be included as esm with the least amount of friction:

```
import "http://localhost:8042/statebus.js"
import "http://localhost:8042/client-library.js"
import "http://unpkg.com/braidify/braidify-client.js"

window.braid_fetch = fetch

export const state = bus.state
```