### PR TITLE
add option to set honk

### DIFF
--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ function import_server (bus, options)
 
     serve: function serve (options) {
         var master = bus
-        bus.honk = 'statelog'
+        bus.honk = options.honk ?? 'statelog'
         master.label = 'master'
 
         // Initialize Options


### PR DESCRIPTION
heyo! normally when i'm developing i don't have a need to see the whole state log printed out. it ends up hiding the information that i'm printing out myself. i couldn't figure out how to set the `honk` level so i did this locally--is there a way to do this already?